### PR TITLE
Rework MathML for Einstein's generalized gravitational equations

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -116,7 +116,11 @@
 		<!-- No Great Magic -->
 		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID46a8c5d53a741</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/23162</dc:source>
-		<meta property="se:production-notes">The 64-Square Madhouse chapters missing 2 and 3, started at 4, so renumbered 4 to 2, etc.</meta>
+		<meta property="se:production-notes">
+			The 64-Square Madhouse chapters missing 2 and 3, started at 4, so renumbered 4 to 2, etc.
+
+			Leiber's source for Einstein's equations in Nice Girl with 5 Husbands appears to be a 1949 frontpage article for the New York Times: https://www.nytimes.com/1949/12/27/archives/new-einstein-theory-gives-a-master-key-to-universe-scientist-after.html
+		</meta>
 		<meta property="se:word-count">185409</meta>
 		<meta property="se:reading-ease.flesch">73.17</meta>
 		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Fritz_Leiber_bibliography#Short_stories</meta>

--- a/src/epub/text/nice-girl-with-5-husbands.xhtml
+++ b/src/epub/text/nice-girl-with-5-husbands.xhtml
@@ -181,7 +181,10 @@
 			<p>During the next days he often returned to the valley. But he never found anything. And he never happened to be near the balancing rock when the time winds blew at ten and two, though once or twice he did see dust devils. Then he went away and eventually forgot.</p>
 			<p>In his casual reading he ran across popular science articles describing the binary system of numbers used in electronic calculating machines, where one and one make ten. He always skipped them. And more than once he saw the four equations expressing Einstein’s generalized theory of gravitation:</p>
 			<figure>
-				<p><m:math alttext="g i - K + ; l = 0"><m:mmultiscripts><m:mi>g</m:mi><m:mi>+</m:mi><m:mi>i</m:mi><m:mi><m:mspace width="0.2em"/>-</m:mi><m:mi>K</m:mi></m:mmultiscripts><m:mtext>;</m:mtext><m:mspace width="0.3em"/><m:mn>l</m:mn><m:mo>=</m:mo><m:mn>0</m:mn></m:math>;<m:math alttext="Γ i = 0"><m:msub><m:mi>Γ</m:mi><m:mi>i</m:mi></m:msub><m:mo>=</m:mo><m:mn>0</m:mn></m:math>;<m:math alttext="R i k = 0"><m:mmultiscripts><m:mi>R</m:mi><m:mi>i</m:mi><m:none/><m:mi>k</m:mi><m:none/></m:mmultiscripts><m:mo>=</m:mo><m:mn>0</m:mn></m:math>;<m:math alttext="g i s ∨ ; s = 0"><m:mi>𝔤</m:mi><m:munderover><m:mo>∨</m:mo><m:mi>s</m:mi><m:mi>is</m:mi></m:munderover><m:mo>=</m:mo><m:mn>0</m:mn></m:math>;!</p>
+				<p><m:math alttext="g_((ik ¦ +−);l) = 0"><m:msub><m:mi>g</m:mi><m:mrow><m:mfrac linethickness="0"><m:mrow><m:mi>i</m:mi><m:mi>k</m:mi></m:mrow><m:mrow><m:mo>+</m:mo><m:mo>−</m:mo></m:mrow></m:mfrac><m:mo>;</m:mo><m:mi>l</m:mi></m:mrow></m:msub><m:mo>=</m:mo><m:mn>0</m:mn></m:math></p>
+				<p><m:math alttext="Γ_i = 0"><m:msub><m:mi>Γ</m:mi><m:mi>i</m:mi></m:msub><m:mo>=</m:mo><m:mn>0</m:mn></m:math></p>
+				<p><m:math alttext="R_(ik) = 0"><m:msub><m:mi>R</m:mi><m:mrow><m:mi>i</m:mi><m:mi>k</m:mi></m:mrow></m:msub><m:mo>=</m:mo><m:mn>0</m:mn></m:math></p>
+				<p><m:math alttext="(𝔤^(is) ̲)_(,s) = 0"><m:msub><m:msup><m:mi>𝔤</m:mi><m:mrow><m:munder accentunder="true"><m:mrow><m:mi>i</m:mi><m:mi>s</m:mi></m:mrow><m:mo>ˇ</m:mo></m:munder></m:mrow></m:msup><m:mrow><m:mo>,</m:mo><m:mi>s</m:mi></m:mrow></m:msub><m:mo>=</m:mo><m:mn>0</m:mn></m:math></p>
 			</figure>
 			<p>He never connected them with the little girl’s chant: “Gik-lo, I-o, Rik-o, Gis-so.”</p>
 		</article>


### PR DESCRIPTION
I made three broad changes to the equations in “Nice Girl with 5 Husbands.”

First, I think the equations are much easier to read on separate lines, not least because they are separated by semicolons yet one equation has a semicolon in it.

Second, I wasn’t satisfied with the rendering, so I researched where the equations came from. John Rennie on StackExchange helpfully pointed me to a 1949 New York Times article, almost certainly Leiber’s source for the equations. I purchased a NYT subscription ($4 per month, what a steal!). After much comparison against both the NYT and Einstein’s two articles, *A Generalization of the Relativistic Theory of Gravitation I* and *II* (way over my head, but I was only focusing on the typography), I’m fairly confident in the new rendering. In particular, Leiber made at least one error (both 𝑘 should be lowercase) and the chevron should be a ˇ accent, not a ∨.

Third, the alt text can be improved by using Unicode math fonts and adding some parentheses. While I’m mostly of the opinion that conveying actual math in plaintext is a futile exercise, improving the alt text is helpful for viewers in browsers like Chromium (which has no MathML support) to get the gist that’s relevant to the story. The current alt text incorrectly swaps some of the letters around.

I added a mention of the NYT article in the production notes, because otherwise it’s a bit difficult to find what Leiber’s illustration was based on. Einstein’s journal articles aren’t relevant because most of the equations were rendered differently and in any case the material is far too dense to be a practical typographic reference.