### PR TITLE
Switch scans from OLS to archive.org

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -47,57 +47,58 @@
 		</meta>
 		<dc:language>en-US</dc:language>
 		<!-- Later Thank You Think -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID566deec271e00</dc:source>
+		<dc:source>https://archive.org/details/Galaxy_v01n01_1950-10</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/50753</dc:source>
 		<!-- Coming Attractions -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID568c5c7340ed3</dc:source>
+		<dc:source>https://archive.org/details/galaxymagazine-1950-11</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/51082</dc:source>
 		<!-- Nice Girl With 5 Husbands -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID569462335b905</dc:source>
+		<dc:source>https://archive.org/details/Galaxy_v02n01_1951-04</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/51101</dc:source>
 		<!-- Appointment In Tomorrow -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID569a67704ac41</dc:source>
+		<dc:source>https://archive.org/details/galaxymagazine-1951-07</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/51152</dc:source>
 		<!-- A Pail Of Air -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID56a41c5e06174</dc:source>
+		<dc:source>https://archive.org/details/galaxymagazine-1951-12</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/51461</dc:source>
 		<!-- Dr. Kometevsky's Day -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID56a427e9d29fe</dc:source>
+		<dc:source>https://archive.org/details/galaxymagazine-1952-02</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/51353</dc:source>
 		<!-- The Moon Is Green -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID4a7239391ad6c</dc:source>
+		<dc:source>https://archive.org/details/galaxymagazine-1952-04</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/29662</dc:source>
 		<!-- Yesterday House -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID566ecfe27492d</dc:source>
+		<dc:source>https://archive.org/details/galaxymagazine-1952-08</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/50905</dc:source>
 		<!-- A Bad Day For Sales -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID567206483c47a</dc:source>
+		<dc:source>https://archive.org/details/galaxymagazine-1953-07</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/50819</dc:source>
 		<!-- Time In The Round -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID5686b9e0d2f80</dc:source>
+		<dc:source>https://archive.org/details/galaxymagazine-1957-05</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/51380</dc:source>
 		<!-- What's He Doing In There -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID4a528adf4bb6b</dc:source>
+		<dc:source>https://archive.org/details/galaxymagazine-1957-12</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/29504</dc:source>
 		<!-- Bread Overhead -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID46707e6c5cf62</dc:source>
+		<dc:source>https://archive.org/details/galaxymagazine-1958-02</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/22579</dc:source>
 		<!-- The Last Letter -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID56a57115eb684</dc:source>
+		<dc:source>https://archive.org/details/Galaxy_v16n02_1958-06</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/51530</dc:source>
 		<!-- Bullet With His Name -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID56a57327df7ca</dc:source>
+		<dc:source>https://archive.org/details/galaxymagazine-1958-07</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/51436</dc:source>
 		<!-- Pipe Dream -->
+		<dc:source>https://archive.org/details/1959-02_IF</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/60664</dc:source>
 		<!-- The Night Of The Long Knives -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID4752ae1860816</dc:source>
+		<dc:source>https://archive.org/details/Amazing_Stories_v34n01_1960-01_UnkSc-cape1736</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/25024</dc:source>
 		<!-- Kreativity For Kats -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID56c3d3148fa9c</dc:source>
+		<dc:source>https://archive.org/details/Galaxy_v19n04_1961-04</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/51493</dc:source>
 		<!-- The Big Engine -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID56c9040352bda</dc:source>
+		<dc:source>https://archive.org/details/Galaxy_v20n02_1962-02</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/51549</dc:source>
 		<!-- The 64-Square Madhouse -->
 		<dc:source>https://archive.org/details/leiberchronicles0000leib</dc:source>
@@ -106,16 +107,16 @@
 		<dc:source>https://www.google.com/books/edition/Ships_to_the_Stars/HFXMyLXYUWYC</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/61243</dc:source>
 		<!-- The Creature from Cleveland Depths -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID466f4ef2e9932</dc:source>
+		<dc:source>https://archive.org/details/Galaxy_v21n02_1962.12</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/23164</dc:source>
 		<!-- X Marks The Pedwalk -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID57a72c6b5b3b5</dc:source>
+		<dc:source>https://archive.org/details/Worlds_of_Tomorrow_v01n01_1963-04_LennyS-EXciter</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/52776</dc:source>
 		<!-- A Hitch In Space -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID57cb240e45cd1</dc:source>
+		<dc:source>https://archive.org/details/Worlds_of_Tomorrow_v01n03_1963-08_dtsg0318.Anon</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/53042</dc:source>
 		<!-- No Great Magic -->
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID46a8c5d53a741</dc:source>
+		<dc:source>https://archive.org/details/Galaxy_v22n02_1963-12</dc:source>
 		<dc:source>https://www.gutenberg.org/ebooks/23162</dc:source>
 		<meta property="se:production-notes">
 			The 64-Square Madhouse chapters missing 2 and 3, started at 4, so renumbered 4 to 2, etc.

--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -23,7 +23,7 @@
 			for<br/>
 			<a href="https://www.gutenberg.org/ebooks/50753">Project Gutenberg</a><br/>
 			and on digital scans available at the<br/>
-			<a href="https://www.pgdp.org/ols/tools/biblio.php?id=projectID566deec271e00">Distributed Proofreaders Open Library System</a>.</p>
+			<a href="https://archive.org/details/Galaxy_v01n01_1950-10">Internet Archive</a>.</p>
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">Ocean Coast</i>,<br/>
 			a painting by<br/>

--- a/src/epub/text/imprint.xhtml
+++ b/src/epub/text/imprint.xhtml
@@ -12,7 +12,7 @@
 				<img alt="The Standard Ebooks logo" src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
 			<p>This ebook is the product of many hours of hard work by volunteers for <a href="https://standardebooks.org">Standard Ebooks</a>, and builds on the hard work of other literature lovers made possible by the public domain.</p>
-			<p>This particular ebook is based on transcriptions produced for <a href="https://www.gutenberg.org/ebooks/50753">Project Gutenberg</a> and on digital scans available at the <a href="https://www.pgdp.org/ols/tools/biblio.php?id=projectID566deec271e00">Distributed Proofreaders Open Library System</a>.</p>
+			<p>This particular ebook is based on transcriptions produced for <a href="https://www.gutenberg.org/ebooks/50753">Project Gutenberg</a> and on digital scans available at the <a href="https://archive.org/details/Galaxy_v01n01_1950-10">Internet Archive</a>.</p>
 			<p>The writing and artwork within are believed to be in the <abbr>U.S.</abbr> public domain, and Standard Ebooks releases this ebook edition under the terms in the <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal Public Domain Dedication</a>. For full license information, see the <a href="uncopyright.xhtml">Uncopyright</a> at the end of this ebook.</p>
 			<p>Standard Ebooks is a volunteer-driven project that produces ebook editions of public domain literature using modern typography, technology, and editorial standards, and distributes them free of cost. You can download this and other ebooks carefully produced for true book lovers at <a href="https://standardebooks.org">standardebooks.org</a>.</p>
 		</section>


### PR DESCRIPTION
There were two stories (64-Square Madhouse and The Snowbank Orbit) that were already non-OLS scans. Although the ones we found were the original magazines the stories appeared in, I didn't change them, since the production was done based on those scans.